### PR TITLE
Simplify and fix Linux install script

### DIFF
--- a/install-scripts/install.sh
+++ b/install-scripts/install.sh
@@ -2,14 +2,9 @@
 
 set -e
 
-function dots {
-    while true; do
-        printf "."
-        sleep 0.1
-    done
-}
+# Download URL
+theme_url="https://raw.githubusercontent.com/Tetrax-10/Nord-Spotify/master"
 
-echo "Downloading"
 # Setup directories to download to
 spice_dir="$(dirname "$(spicetify -c)")"
 theme_dir="${spice_dir}/Themes"
@@ -20,32 +15,13 @@ mkdir -p "${theme_dir}/Nord-Spotify"
 mkdir -p "${ext_dir}"
 
 # Download latest tagged files into correct directories
-theme_url="https://raw.githubusercontent.com/Tetrax-10/Nord-Spotify/master/Nord-Spotify"
-
-# Call dots function in background
-dots &
-dots_pid=$!
-# Avoid kill message for dots
-disown
-
-# Store PIDs of curls to kill later
-pids=()
-curl --silent --output "${theme_dir}/Nord-Spotify/color.ini" "${theme_url}/color.ini" &
-pids+=($!)
-curl --silent --output "${theme_dir}/Nord-Spotify/user.css" "${theme_url}/user.css" &
-pids+=($!)
-curl --silent --output "${ext_dir}/injectNord.js" "https://raw.githubusercontent.com/Tetrax-10/Nord-Spotify/master/src/injectNord.js" &
-pids+=($!)
-
-# Wait for all curls to finish and kill dots
-for pid in "${pids[@]}"; do
-    wait $pid
-done
-kill $dots_pid
-echo " Done"
+echo "Downloading Nord-Spotify..."
+curl --silent --output "${theme_dir}/Nord-Spotify/color.ini" "${theme_url}/Nord-Spotify/color.ini"
+curl --silent --output "${theme_dir}/Nord-Spotify/user.css" "${theme_url}/Nord-Spotify/user.css"
+curl --silent --output "${ext_dir}/injectNord.js" "${theme_url}/src/injectNord.js"
 
 # Apply theme
-echo "Applying theme"
+echo "Applying theme..."
 spicetify config extensions nord.js-
 spicetify config current_theme Nord-Spotify color_scheme Spotify extensions injectNord.js inject_css 1 replace_colors 1 overwrite_assets 1
 spicetify apply


### PR DESCRIPTION
Currently the install script for Linux and MAC (install.sh) is broken and will not work on Linux systems.
The reason is the heavy usage of **bash** features which conflicts with the **sh** interpreter, which is used by the script and also recommended for universal install scripts like this one.

Keywords used in the script like *function* or *disown* are not available in pure *sh* and are a *bash* feature.

I took the radical approach and removed everything that was not needed to actually install Nord-Spotify. Due to that the used bash keyword were also removed in the process. Now the scripts works like it should with *sh*.

The "progression" bar (which just printed dots inside the terminal) is not needed at all in my opinion because the download of the necessary files only takes a second. So that should not be too much of a loss. Running the **curl** calls in parallel is also not needed due to the previously stated rather small size of files to download.

How it worked before on Linux (Using the install command from the README):

-> curl -fsSL https://raw.githubusercontent.com/Tetrax-10/Nord-Spotify/master/install-scripts/install.sh | sh
sh: 5: function: not found


How it works with the changes done in this PR:

-> curl -fsSL https://raw.githubusercontent.com/FancyChaos/Nord-Spotify/fix_linux_install/install-scripts/install.sh | sh
Downloading Nord-Spotify...
Applying theme...
warning Config "extensions" unchanged: nord.js is not on the list.
success Config changed: current_theme = Nord-Spotify
info Run "spicetify apply" to apply new config
success Config changed: color_scheme = Spotify
info Run "spicetify apply" to apply new config
success Config changed: extensions = injectNord.js
info Run "spicetify apply" to apply new config
success Config changed: inject_css = 1
info Run "spicetify apply" to apply new config
success Config changed: replace_colors = 1
info Run "spicetify apply" to apply new config
success Config changed: overwrite_assets = 1
info Run "spicetify apply" to apply new config
spicetify v2.16.2
Overwriting themed assets:
OK
Transferring user.css:
OK
Applying additional modifications:
OK
Transferring extensions:
OK
Transferring custom apps:
OK
success Spotify is spiced up!
All done!


