### PR TITLE
Linux install script: Choose between online and offline version

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ iwr -useb https://raw.githubusercontent.com/Tetrax-10/Nord-Spotify/master/instal
 ### Mac/Linux
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/Tetrax-10/Nord-Spotify/master/install-scripts/install.sh | sh
+sh -c "$(curl -fsSL https://raw.githubusercontent.com/Tetrax-10/Nord-Spotify/master/install-scripts/install.sh)"
 ```
 
 <br />

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ iwr -useb https://raw.githubusercontent.com/Tetrax-10/Nord-Spotify/master/instal
 ### Mac/Linux
 
 ```sh
-sh -c "$(curl -fsSL https://raw.githubusercontent.com/Tetrax-10/Nord-Spotify/master/install-scripts/install.sh)"
+curl -fsSL https://raw.githubusercontent.com/Tetrax-10/Nord-Spotify/master/install-scripts/install.sh | sh
 ```
 
 <br />

--- a/install-scripts/install.sh
+++ b/install-scripts/install.sh
@@ -8,22 +8,71 @@ theme_url="https://raw.githubusercontent.com/Tetrax-10/Nord-Spotify/master"
 # Setup directories to download to
 spice_dir="$(dirname "$(spicetify -c)")"
 theme_dir="${spice_dir}/Themes"
+nord_dir="${theme_dir}/Nord-Spotify"
+snippet_dir="${nord_dir}/assets/Nord-Spotify/src/Snippets"
 ext_dir="${spice_dir}/Extensions"
 
 # Make directories if needed
-mkdir -p "${theme_dir}/Nord-Spotify"
+mkdir -p "${nord_dir}"
 mkdir -p "${ext_dir}"
 
-# Download latest tagged files into correct directories
-echo "Downloading Nord-Spotify..."
-curl --silent --output "${theme_dir}/Nord-Spotify/color.ini" "${theme_url}/Nord-Spotify/color.ini"
-curl --silent --output "${theme_dir}/Nord-Spotify/user.css" "${theme_url}/Nord-Spotify/user.css"
-curl --silent --output "${ext_dir}/injectNord.js" "${theme_url}/src/injectNord.js"
+cat <<EOF
 
-# Apply theme
-echo "Applying theme..."
-spicetify config extensions nord.js-
-spicetify config current_theme Nord-Spotify color_scheme Spotify extensions injectNord.js inject_css 1 replace_colors 1 overwrite_assets 1
-spicetify apply
+Nord Spotify can be installed with auto updates included (online version) or with auto updates excluded (offline version):
+1: Auto Update - Theme requires internet access. Updates the Theme automatically when there is a new update available
+2: Offline     - Works without internet and thus gives better performance. Re-running this shell script installs the latest update
 
-echo "All done!"
+EOF
+
+CHOICE="0"
+while [ $CHOICE != "1" ] && [ $CHOICE != "2" ]
+do
+    printf "Please choose a version: "
+    read -r CHOICE
+done
+
+# For visual indentation
+echo ""
+
+# Install online or offline version depending on users choice
+if [ "$CHOICE" = "1" ]
+then
+    echo "Installing Nord Spotify (Auto Update Version)"
+
+    echo "Fetching Theme from GitHub\n"
+    curl --silent --output "${nord_dir}/color.ini" "${theme_url}/Nord-Spotify/color.ini"
+    curl --silent --output "${nord_dir}/user.css" "${theme_url}/Nord-Spotify/user.css"
+    curl --silent --output "${ext_dir}/injectNord.js" "${theme_url}/src/injectNord.js"
+
+    echo "Changing configuration"
+    spicetify config extensions nord.js-
+    spicetify config current_theme Nord-Spotify color_scheme Spotify extensions injectNord.js inject_css 1 replace_colors 1 overwrite_assets 1
+else
+    echo "Installing Nord Spotify (Offline Version)"
+    mkdir -p "${snippet_dir}"
+
+    echo "Fetching Theme from GitHub\n"
+    curl --silent --output "${snippet_dir}/NewUI.css" "${theme_url}/src/Snippets/NewUI.css"
+    curl --silent --output "${snippet_dir}/OldUI.css" "${theme_url}/src/Snippets/OldUI.css"
+
+    curl --silent --output "${nord_dir}/color.ini" "${theme_url}/Nord-Spotify/color.ini"
+    curl --silent --output "${nord_dir}/user.css" "${theme_url}/src/nord.css"
+    curl --silent --output "${ext_dir}/nord.js" "${theme_url}/src/nord.js"
+
+    echo "Changing configuration"
+    spicetify config extensions injectNord.js-
+    spicetify config current_theme Nord-Spotify color_scheme Spotify extensions nord.js inject_css 1 replace_colors 1 overwrite_assets 1
+fi
+
+# Bacup spotify if no backup version found
+backup_version=$(grep version  "${spice_dir}/config-xpui.ini" 2>/dev/null | sed 's/version = //g')
+if [ "$backup_version" = "" ]
+then
+    echo "Making backup and applying Theme"
+    spicetify backup apply
+else
+    echo "Applying Theme"
+    spicetify apply
+fi
+
+echo "\nNord Spotify installed successfully"

--- a/install-scripts/install.sh
+++ b/install-scripts/install.sh
@@ -28,7 +28,7 @@ CHOICE="0"
 while [ $CHOICE != "1" ] && [ $CHOICE != "2" ]
 do
     printf "Please choose a version: "
-    read -r CHOICE
+    read -r CHOICE </dev/tty
 done
 
 # For visual indentation


### PR DESCRIPTION
Hello there.
Here is the PR to provide the user the option to install the online or offline version of Nord Spotify on Linux.

The install command in the README had to be changed so user input can be read. We can not read the user input from stdin anymore when executed with **sh** after the pipe (**|**).

An automatic install of the online or offline version is still possible by providing *yes 1* or *yes 2* to the install command (1=online, 2=offline):
> yes 1 | sh -c "$(curl -fsSL https://raw.githubusercontent.com/Tetrax-10/Nord-Spotify/master/install-scripts/install.sh)"
> yes 2 | sh -c "$(curl -fsSL https://raw.githubusercontent.com/Tetrax-10/Nord-Spotify/master/install-scripts/install.sh)"

Example of how the install process now looks:
```sh
-> sh -c "$(curl -fsSL https://raw.githubusercontent.com/FancyChaos/Nord-Spotify/linux_install_offline_option/install-scripts/install.sh)"

Nord Spotify can be installed with auto updates included (online version) or with auto updates excluded (offline version):
1: Auto Update - Theme requires internet access. Updates the Theme automatically when there is a new update available
2: Offline     - Works without internet and thus gives better performance. Re-running this shell script installs the latest update

Please choose a version: 1

Installing Nord Spotify (Auto Update Version)
Fetching Theme from GitHub

Changing configuration
warning Config "extensions" unchanged: nord.js is not on the list.
success Config changed: current_theme = Nord-Spotify
info Run "spicetify apply" to apply new config
success Config changed: color_scheme = Spotify
info Run "spicetify apply" to apply new config
warning Config "extensions" unchanged: injectNord.js is already in the list.
success Config changed: inject_css = 1
info Run "spicetify apply" to apply new config
success Config changed: replace_colors = 1
info Run "spicetify apply" to apply new config
success Config changed: overwrite_assets = 1
info Run "spicetify apply" to apply new config
Applying Theme
spicetify v2.16.2
Overwriting themed assets:
OK
Transferring user.css:
OK
Applying additional modifications:
OK
Transferring extensions:
OK
success Spotify is spiced up!

Nord Spotify installed successfully
```

I tried to keep this script as close as possible to the power shell one. Spotify will also be backed up by spicetify if not already done.

**BIG DISCLAIMER**
Unfortunately I do now own any MacOS device and can therefore not test if all changes work for it!
But given that the install script is POSIX sh it should work, but I can not guarantee it.