### PR TITLE
chore: Use variables for progress bar

### DIFF
--- a/theme/src/main/player/player.scss
+++ b/theme/src/main/player/player.scss
@@ -23,18 +23,20 @@
 
 //////////////////////////////////////// Progress Bar ////////////////////////////////////////
 
-// progress bar (how much filled)
-.x-progressBar-fillColor {
-    border-radius: 50px;
-    height: 6px;
-    background-color: var(--spice-custom-selected-button) !important;
-    transition: transform, 0s, ease, 0.25s;
+.progress-bar {
+    --progress-bar-height: 6px;
+    --progress-bar-radius: 0;
+    // Color for fill
+    --fg-color: var(--spice-custom-selected-button);
+    --is-active-fg-color: var(--spice-custom-selected-button);
+    // Color for background
+    --bg-color: var(--spice-custom-main-secondary)
 }
 
-// progress bar (how much remaining)
-.x-progressBar-sliderArea {
-    height: 6px;
-    background-color: var(--spice-custom-main-secondary) !important;
+// Apply radius only to fill, and transition
+.x-progressBar-fillColor {
+    border-radius: 50px;
+    transition: transform, 0s, ease, 0.25s;
 }
 
 //////////////////////////////////////// Left Player ////////////////////////////////////////

--- a/theme/src/main/player/player.scss
+++ b/theme/src/main/player/player.scss
@@ -27,10 +27,10 @@
     --progress-bar-height: 6px;
     --progress-bar-radius: 0;
     // Color for fill
-    --fg-color: var(--spice-custom-selected-button);
-    --is-active-fg-color: var(--spice-custom-selected-button);
+    --fg-color: var(--spice-custom-selected-button) !important;
+    --is-active-fg-color: var(--spice-custom-selected-button) !important;
     // Color for background
-    --bg-color: var(--spice-custom-main-secondary)
+    --bg-color: var(--spice-custom-main-secondary) !important;
 }
 
 // Apply radius only to fill, and transition


### PR DESCRIPTION
Make the progress bar use variables instead of hard-styling it, in line with Spotify's conventions.

This change will allow extensions to inject into the playbar and know it's dimensions correctly. Because the styles are hardcoded instead of given through variables like Spotify normally does, my extension takes Spotify's default, unchanged dimensions instead of those given by Nord.

I have not tested this change - please test before merging.